### PR TITLE
Fix the relative jump (JR, JumpToOffset) logic

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,3 +15,4 @@ A Game Boy emulator. This project is in progress and will most likely stay that 
 * http://www.emulatronia.com/doctec/consolas/gameboy/gameboy.txt
 * https://files.nekoblog.org/uploads/pdf/39999184-GameBoy-Programming-Manual.pdf
 * https://ia803208.us.archive.org/9/items/GameBoyProgManVer1.1/GameBoyProgManVer1.1.pdf
+* http://www.zilog.com/docs/z80/um0080.pdf

--- a/gejmboj_cpu/src/instructions/misc.rs
+++ b/gejmboj_cpu/src/instructions/misc.rs
@@ -52,7 +52,8 @@ instruction_group! {
             Ok(1)
         }
 
-        /// Flips the zero (Z) and carry (C) flags and clears the half-carry (H) flag
+        /// Flips the zero (Z) and carry (C) flags and clears the half-carry (H) flag.
+        /// Decimal Adjust Accumulator.
         DAA() [1] => {
             let value = registers.get_flags();
             let value = value & 0b1101_0000; // Clear H


### PR DESCRIPTION
Ensures that the operand is handled as a signed 8 bit integer and that the offsets are applied correctly. Adds a lot of tests to verify the logic.